### PR TITLE
Submit with specific scheduler

### DIFF
--- a/mass/exception.py
+++ b/mass/exception.py
@@ -20,3 +20,9 @@ class TaskError(Exception):
         super().__init__()
         self.reason = reason
         self.details = details
+
+
+class UnsupportedScheduler(Exception):
+    """Raised while scheduler is not supported.
+    """
+    pass

--- a/mass/utils.py
+++ b/mass/utils.py
@@ -8,13 +8,16 @@
 import json
 
 # local modules
+from mass.exception import UnsupportedScheduler
 from mass.input_handler import InputHandler
 from mass.scheduler.swf import config
 
 
-def submit(job, protocol=None, priority=1):
+def submit(job, protocol=None, priority=1, scheduler='swf'):
     """Submit mass job to SWF with specific priority.
     """
+    if scheduler != 'swf':
+        raise UnsupportedScheduler(scheduler)
     import boto3
     client = boto3.client('swf', region_name=config.REGION)
     handler = InputHandler(protocol)

--- a/mass/utils.py
+++ b/mass/utils.py
@@ -10,7 +10,6 @@ import json
 # local modules
 from mass.exception import UnsupportedScheduler
 from mass.input_handler import InputHandler
-from mass.scheduler.swf import config
 
 
 def submit(job, protocol=None, priority=1, scheduler='swf'):
@@ -18,6 +17,7 @@ def submit(job, protocol=None, priority=1, scheduler='swf'):
     """
     if scheduler != 'swf':
         raise UnsupportedScheduler(scheduler)
+    from mass.scheduler.swf import config
     import boto3
     client = boto3.client('swf', region_name=config.REGION)
     handler = InputHandler(protocol)


### PR DESCRIPTION
- Add scheduler as argument to mass.submit.
- Now only 'swf' is supported.
