### PR TITLE
add role as input to error handler

### DIFF
--- a/mass/scheduler/worker.py
+++ b/mass/scheduler/worker.py
@@ -73,7 +73,7 @@ class BaseWorker(object):
             for exception, handler_function in self.handler_functions.items():
                 if issubclass(value.__class__, exception):
                     try:
-                        handler_function(etype, value, tb, self.role_functions[role], kwargs)
+                        handler_function(etype, value, tb, role, self.role_functions[role], kwargs)
                     except Exception:
                         etype, value, tb = sys.exc_info()
                         raise TaskError(repr(value), traceback.format_exc())

--- a/mass/scheduler/worker.py
+++ b/mass/scheduler/worker.py
@@ -37,13 +37,14 @@ class BaseWorker(object):
 
         The inputs of handler function:
         * etype, value, tb: from sys.exc_info()
+        * role: role name
         * func: role function
         * kwargs: input of role function
 
         Example:
 
         @worker.handle(Exception)
-        def handler(etype, value, tb, func, kwargs):
+        def handler(etype, value, tb, role, func, kwargs):
             format_exc = ''.join(traceback.format_exception(etype, value, tb, limit=None))
             print(format_exc)
         """

--- a/tests/test_mass.py
+++ b/tests/test_mass.py
@@ -57,7 +57,7 @@ def worker(request):
         print(output)
 
     @worker.handle(Exception)
-    def handle_error(etype, value, tb, func, kwargs):
+    def handle_error(etype, value, tb, role, func, kwargs):
         print('=== type ===')
         print(type(etype), etype)
         print('=== value ===')
@@ -65,6 +65,8 @@ def worker(request):
         print('=== traceback ===')
         print(''.join(traceback.format_tb(tb)))
         format_exc = ''.join(traceback.format_exception(etype, value, tb, limit=None))
+        print('=== role ===')
+        print(role)
         print('=== func ===')
         print(func)
         print('=== kwargs ===')


### PR DESCRIPTION
Example

``` python
@worker.handle(Exception)
def handle_error(etype, value, tb, role, func, kwargs):
    print('=== type ===')
    print(type(etype), etype)
    print('=== value ===')
    print(type(value), value)
    print('=== traceback ===')
    print(''.join(traceback.format_tb(tb)))
    print('=== role ===')
    print(role)
    print('=== func ===')
    print(func)
    print('=== kwargs ===')
    print(json.dumps(kwargs))
```
